### PR TITLE
Enable/disable svm support at runtime

### DIFF
--- a/aten/src/ATen/xpu/CachingHostAllocator.cpp
+++ b/aten/src/ATen/xpu/CachingHostAllocator.cpp
@@ -18,12 +18,17 @@ struct XPUCachingHostAllocatorImpl
   /* These following functions are runtime-related. */
   void allocate_host_memory(size_t size, void** ptr) override {
 #ifdef USE_XPU_SVM
-    // PowerOf2Ceil() guarantees that size is the power of two.
-    if (size >= c10::CachingAllocator::kRoundLarge) {
-      *ptr = std::aligned_alloc(c10::CachingAllocator::kRoundLarge, size);
-      madvise(*ptr, size, MADV_HUGEPAGE);
+    if (c10::CachingAllocator::AcceleratorAllocatorConfig::use_svm()) {
+      // PowerOf2Ceil() guarantees that size is the power of two.
+      if (size >= c10::CachingAllocator::kRoundLarge) {
+        *ptr = std::aligned_alloc(c10::CachingAllocator::kRoundLarge, size);
+        madvise(*ptr, size, MADV_HUGEPAGE);
+      } else {
+        *ptr = std::malloc(size);
+      }
     } else {
-      *ptr = std::malloc(size);
+      *ptr = sycl::aligned_alloc_host(
+          kHostAlignment, size, c10::xpu::get_device_context());
     }
 #else
     *ptr = sycl::aligned_alloc_host(
@@ -33,7 +38,11 @@ struct XPUCachingHostAllocatorImpl
 
   void free_block(Block* block) override {
 #ifdef USE_XPU_SVM
-    std::free(block->ptr_);
+    if (c10::CachingAllocator::AcceleratorAllocatorConfig::use_svm()) {
+      std::free(block->ptr_);
+    } else {
+      sycl::free(block->ptr_, c10::xpu::get_device_context());
+    }
 #else
     sycl::free(block->ptr_, c10::xpu::get_device_context());
 #endif

--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -207,6 +207,22 @@ size_t AcceleratorAllocatorConfig::parseExpandableSegments(
   return i;
 }
 
+size_t AcceleratorAllocatorConfig::parseSVM(
+    const ConfigTokenizer& tokenizer,
+    size_t i) {
+  tokenizer.checkToken(++i, ":");
+  use_svm_ = tokenizer.toBool(++i);
+#ifndef USE_XPU_SVM
+  TORCH_CHECK(
+      !use_svm_,
+      "PYTORCH_ALLOC_CONF=svm:True is set, but this build was compiled "
+      "without USE_XPU_SVM support. To enable SVM, rebuild PyTorch with "
+      "USE_XPU_SVM=1.");
+#endif
+
+  return i;
+}
+
 size_t AcceleratorAllocatorConfig::parsePinnedUseBackgroundThreads(
     const ConfigTokenizer& tokenizer,
     size_t i) {
@@ -256,6 +272,8 @@ void AcceleratorAllocatorConfig::parseArgs(const std::string& env) {
       i = parseExpandableSegments(tokenizer, i);
     } else if (key == "pinned_use_background_threads") {
       i = parsePinnedUseBackgroundThreads(tokenizer, i);
+    } else if (key == "svm") {
+      i = parseSVM(tokenizer, i);
     } else {
       // If a device-specific configuration parser hook is registered, it will
       // check if the key is unrecognized.

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -225,6 +225,13 @@ class C10_API AcceleratorAllocatorConfig {
 
   /* Settings for both device and host allocator */
 
+  // Returns whether shared virtual memory (SVM) support is enabled. This allows
+  // the allocator to use SVM features if supported by the hardware and backend.
+  // Default is false (SVM support disabled).
+  static bool use_svm() {
+    return instance().use_svm_;
+  }
+
   // Returns the current allocator settings as a string. This string is useful
   // to expand device-specific allocator configurations
   static std::string last_allocator_settings() {
@@ -242,7 +249,8 @@ class C10_API AcceleratorAllocatorConfig {
         "garbage_collection_threshold",
         "roundup_power2_divisions",
         "expandable_segments",
-        "pinned_use_background_threads"};
+        "pinned_use_background_threads",
+        "svm"};
     return keys;
   }
 
@@ -331,6 +339,11 @@ class C10_API AcceleratorAllocatorConfig {
       const ConfigTokenizer& tokenizer,
       size_t i);
 
+  /* Internal functions for both device and host allocator */
+
+  // Parse `svm` from environment variable.
+  size_t parseSVM(const ConfigTokenizer& tokenizer, size_t i);
+
   /* The following members are specifically used for the device allocator. */
 
   // "large" allocations may be packed in blocks of this size
@@ -355,6 +368,8 @@ class C10_API AcceleratorAllocatorConfig {
   std::atomic<bool> pinned_use_background_threads_{false};
 
   /* The following members are used for both device and host allocator. */
+  // A flag to enable shared virtual memory (SVM) support.
+  std::atomic<bool> use_svm_{false};
 
   // Record the last allocator config environment setting.
   std::mutex last_allocator_settings_mutex_;

--- a/c10/xpu/XPUCachingAllocator.cpp
+++ b/c10/xpu/XPUCachingAllocator.cpp
@@ -418,9 +418,17 @@ void allocPrimitive(void** ptr, size_t size, AllocParams& p) {
     static_assert(
         kSmallBuffer == kRoundLarge && kRoundLarge == 2097152,
         "kSmallBuffer being equal to kRoundLarge, which is 2 MiB.");
-    // get_allocation_size guarantee that size is a multiple of kRoundLarge.
-    *ptr = std::aligned_alloc(kRoundLarge, size);
-    madvise(*ptr, size, MADV_HUGEPAGE);
+    if (c10::CachingAllocator::AcceleratorAllocatorConfig::use_svm()) {
+      // get_allocation_size guarantee that size is a multiple of kRoundLarge.
+      *ptr = std::aligned_alloc(kRoundLarge, size);
+      madvise(*ptr, size, MADV_HUGEPAGE);
+    } else {
+      *ptr = sycl::aligned_alloc_device(
+          kDeviceAlignment,
+          size,
+          xpu::get_raw_device(p.device()),
+          xpu::get_device_context());
+    }
 #else
     *ptr = sycl::aligned_alloc_device(
         kDeviceAlignment,
@@ -436,7 +444,11 @@ void deletePrimitive(void* ptr, BlockPool* pool) {
     pool->owner_PrivatePool->allocator()->raw_delete(ptr);
   } else {
 #ifdef USE_XPU_SVM
-    std::free(ptr);
+    if (c10::CachingAllocator::AcceleratorAllocatorConfig::use_svm()) {
+      std::free(ptr);
+    } else {
+      sycl::free(ptr, xpu::get_device_context());
+    }
 #else
     sycl::free(ptr, xpu::get_device_context());
 #endif
@@ -1830,9 +1842,12 @@ class NativeCachingAllocator : public XPUAllocator {
 
   void init(DeviceIndex device_count) override {
 #ifdef USE_XPU_SVM
-    TORCH_WARN_ONCE(
-        "XPU Caching Allocator is using the experimental SVM allocator. ",
-        "If you encounter issues, consider rebuilding PyTorch with `USE_XPU_SVM=0` to use the non-SVM allocator.");
+    if (c10::CachingAllocator::AcceleratorAllocatorConfig::use_svm()) {
+      TORCH_WARN_ONCE(
+          "XPU Caching Allocator is using the experimental SVM (Shared Virtual Memory) allocator. "
+          "If you encounter issues, you can disable it at runtime by setting "
+          "PYTORCH_ALLOC_CONF=svm:False, or at build time by rebuilding PyTorch without USE_XPU_SVM.");
+    }
 #endif
     const auto size = static_cast<DeviceIndex>(device_allocators.size());
     if (size < device_count) {

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -351,8 +351,15 @@ RAIIDataPtr RAII_gpuMalloc(size_t num_bytes) {
   sycl::queue* queue_ptr = nullptr;
   aoti_torch_get_current_sycl_queue((void**)&queue_ptr);
 #if defined(USE_XPU_SVM)
-  void* data_ptr = malloc(num_bytes);
-  auto deleter = [](void* ptr) { free(ptr); };
+  void* data_ptr = nullptr;
+  std::function<void(void*)> deleter;
+  if (aoti_torch_xpu_use_svm()) {
+    data_ptr = malloc(num_bytes);
+    deleter = [](void* ptr) { free(ptr); };
+  } else {
+    data_ptr = sycl::malloc_device(num_bytes, *queue_ptr);
+    deleter = [queue_ptr](void* ptr) { sycl::free(ptr, *queue_ptr); };
+  }
 #else
   void* data_ptr = sycl::malloc_device(num_bytes, *queue_ptr);
   auto deleter = [queue_ptr](void* ptr) { sycl::free(ptr, *queue_ptr); };

--- a/torch/csrc/inductor/aoti_torch/c/shim_xpu.h
+++ b/torch/csrc/inductor/aoti_torch/c/shim_xpu.h
@@ -46,6 +46,13 @@ aoti_torch_set_current_xpu_device(const int32_t& device_index);
 
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_get_current_sycl_queue(void** ret);
 
+#ifdef USE_XPU_SVM
+// Returns true if the XPU allocator is configured to use Shared Virtual Memory
+// (SVM). This shim exists so that aoti_runtime code can query the allocator
+// config without taking a direct dependency on c10 headers.
+AOTI_TORCH_EXPORT bool aoti_torch_xpu_use_svm();
+#endif // USE_XPU_SVM
+
 #if AT_MKLDNN_ENABLED()
 
 AOTI_TORCH_EXPORT AOTITorchError

--- a/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
+++ b/torch/csrc/inductor/aoti_torch/shim_xpu.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/inductor/aoti_torch/c/shim_xpu.h>
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
+#include <c10/core/AllocatorConfig.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/StreamGuard.h>
@@ -77,6 +78,12 @@ AOTITorchError aoti_torch_get_current_sycl_queue(void** ret) {
     *ret = &(at::xpu::getCurrentXPUStream(device_index).queue());
   });
 }
+
+#ifdef USE_XPU_SVM
+bool aoti_torch_xpu_use_svm() {
+  return c10::CachingAllocator::AcceleratorAllocatorConfig::use_svm();
+}
+#endif // USE_XPU_SVM
 
 #if AT_MKLDNN_ENABLED()
 #include <ATen/native/mkldnn/xpu/Conv.h>


### PR DESCRIPTION
# Motivation
Enable svm support at runtime. We disable it by default; use the following method to enable it.
1. Controlled by environment variable: `PYTORCH_ALLOC_CONF=svm:True`
2. Controlled by API: `torch._C._accelerator_setAllocatorSettings("svm:True")`

# Test Case:
1. test environment variable:
<img width="2428" height="438" alt="image" src="https://github.com/user-attachments/assets/70578990-861e-4363-9c66-fb5bd37efb00" />
2. test PyTorch API:
<img width="1830" height="305" alt="image" src="https://github.com/user-attachments/assets/8009f9bf-9d2e-482e-bb41-8dda0592d143" />
